### PR TITLE
Small changes, refactor and cleanups

### DIFF
--- a/src/main/kotlin/io/github/gunpowder/GunpowderUtilitiesModule.kt
+++ b/src/main/kotlin/io/github/gunpowder/GunpowderUtilitiesModule.kt
@@ -38,7 +38,7 @@ class GunpowderUtilitiesModule : GunpowderModule {
     override fun registerCommands() {
         gunpowder.registry.registerCommand(EnderchestCommand::register)
         gunpowder.registry.registerCommand(FlightCommand::register)
-        gunpowder.registry.registerCommand(GodCommand::register)
+        gunpowder.registry.registerCommand(InvulnerableCommand::register)
         gunpowder.registry.registerCommand(HatCommand::register)
         gunpowder.registry.registerCommand(HeadCommand::register)
         gunpowder.registry.registerCommand(HealCommand::register)

--- a/src/main/kotlin/io/github/gunpowder/commands/FlightCommand.kt
+++ b/src/main/kotlin/io/github/gunpowder/commands/FlightCommand.kt
@@ -36,7 +36,7 @@ import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.text.LiteralText
 
 object FlightCommand {
-    private val ESSENTIALS_ABILITY_FLY: AbilitySource = Pal.getAbilitySource("essentials", "flight");
+    private val ESSENTIALS_ABILITY_FLY = Pal.getAbilitySource("essentials", "flight");
 
     fun register(dispatcher: CommandDispatcher<ServerCommandSource>) {
         Command.builder(dispatcher) {

--- a/src/main/kotlin/io/github/gunpowder/commands/FlightCommand.kt
+++ b/src/main/kotlin/io/github/gunpowder/commands/FlightCommand.kt
@@ -27,6 +27,7 @@ package io.github.gunpowder.commands
 import com.mojang.brigadier.CommandDispatcher
 import com.mojang.brigadier.context.CommandContext
 import io.github.gunpowder.api.builders.Command
+import io.github.ladysnake.pal.AbilitySource
 import io.github.ladysnake.pal.Pal
 import io.github.ladysnake.pal.VanillaAbilities
 import net.minecraft.command.argument.EntityArgumentType
@@ -35,7 +36,7 @@ import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.text.LiteralText
 
 object FlightCommand {
-    val ESSENTIALS_ABILITY_FLY = Pal.getAbilitySource("essentials", "flight");
+    private val ESSENTIALS_ABILITY_FLY: AbilitySource = Pal.getAbilitySource("essentials", "flight");
 
     fun register(dispatcher: CommandDispatcher<ServerCommandSource>) {
         Command.builder(dispatcher) {
@@ -43,9 +44,8 @@ object FlightCommand {
                 requires { it.hasPermissionLevel(4) }
 
                 executes(FlightCommand::toggleFlightSelf)
-                argument("player", EntityArgumentType.player()) {
+                argument("target", EntityArgumentType.player()) {
                     requires { it.hasPermissionLevel(4) }
-
                     executes(FlightCommand::toggleFlightOther)
                 }
             }
@@ -66,7 +66,7 @@ object FlightCommand {
 
     private fun toggleFlightOther(commandContext: CommandContext<ServerCommandSource>): Int {
         // Get player
-        val player = EntityArgumentType.getPlayer(commandContext, "player")
+        val player = EntityArgumentType.getPlayer(commandContext, "target")
 
         // Set flight
         toggleFlight(player)

--- a/src/main/kotlin/io/github/gunpowder/commands/HatCommand.kt
+++ b/src/main/kotlin/io/github/gunpowder/commands/HatCommand.kt
@@ -66,7 +66,7 @@ object HatCommand {
                 LiteralText("Enjoy your new ")
                         .append(TranslatableText(hand.item.translationKey).formatted(Formatting.YELLOW))
                         .append(LiteralText(" hat!")),
-                false
+                true
         )
         return 1
     }

--- a/src/main/kotlin/io/github/gunpowder/commands/HatCommand.kt
+++ b/src/main/kotlin/io/github/gunpowder/commands/HatCommand.kt
@@ -28,6 +28,7 @@ import com.mojang.brigadier.CommandDispatcher
 import com.mojang.brigadier.context.CommandContext
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
 import io.github.gunpowder.api.builders.Command
+import io.github.gunpowder.api.builders.Text
 import net.minecraft.item.Wearable
 import net.minecraft.server.command.ServerCommandSource
 import net.minecraft.text.LiteralText
@@ -63,9 +64,13 @@ object HatCommand {
         player.setStackInHand(Hand.MAIN_HAND, head)
         player.inventory.armor[3] = hand
         player.sendMessage(
-                LiteralText("Enjoy your new ")
-                        .append(TranslatableText(hand.item.translationKey).formatted(Formatting.YELLOW))
-                        .append(LiteralText(" hat!")),
+                Text.builder {
+                    text("Enjoy your new ")
+                    text(TranslatableText(hand.item.translationKey)) {
+                        color(Formatting.YELLOW)
+                    }
+                    text(" hat!")
+                },
                 true
         )
         return 1

--- a/src/main/kotlin/io/github/gunpowder/commands/HealCommand.kt
+++ b/src/main/kotlin/io/github/gunpowder/commands/HealCommand.kt
@@ -39,7 +39,7 @@ object HealCommand {
                 requires { it.hasPermissionLevel(4) }
                 executes(HealCommand::healSelf)
 
-                argument("player", EntityArgumentType.player()) {
+                argument("target", EntityArgumentType.player()) {
                     requires { it.hasPermissionLevel(4) }
                     executes(HealCommand::healOther)
                 }
@@ -56,7 +56,7 @@ object HealCommand {
     }
 
     private fun healOther(context: CommandContext<ServerCommandSource>): Int {
-        val player = EntityArgumentType.getPlayer(context, "player")
+        val player = EntityArgumentType.getPlayer(context, "target")
         healPlayer(player)
         context.source.sendFeedback(
                 LiteralText("Successfully healed ${player.displayName.asString()}"),

--- a/src/main/kotlin/io/github/gunpowder/commands/InvulnerableCommand.kt
+++ b/src/main/kotlin/io/github/gunpowder/commands/InvulnerableCommand.kt
@@ -36,7 +36,7 @@ import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.text.LiteralText
 
 object InvulnerableCommand {
-    private val ESSENTIALS_ABILITY_GOD: AbilitySource = Pal.getAbilitySource("essentials", "invulnerable")
+    private val ESSENTIALS_ABILITY_GOD = Pal.getAbilitySource("essentials", "invulnerable")
 
     fun register(dispatcher: CommandDispatcher<ServerCommandSource>) {
         Command.builder(dispatcher) {

--- a/src/main/kotlin/io/github/gunpowder/commands/InvulnerableCommand.kt
+++ b/src/main/kotlin/io/github/gunpowder/commands/InvulnerableCommand.kt
@@ -27,6 +27,7 @@ package io.github.gunpowder.commands
 import com.mojang.brigadier.CommandDispatcher
 import com.mojang.brigadier.context.CommandContext
 import io.github.gunpowder.api.builders.Command
+import io.github.ladysnake.pal.AbilitySource
 import io.github.ladysnake.pal.Pal
 import io.github.ladysnake.pal.VanillaAbilities
 import net.minecraft.command.argument.EntityArgumentType
@@ -34,18 +35,17 @@ import net.minecraft.server.command.ServerCommandSource
 import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.text.LiteralText
 
-object GodCommand {
-    val ESSENTIALS_ABILITY_GOD = Pal.getAbilitySource("essentials", "godmode")
+object InvulnerableCommand {
+    private val ESSENTIALS_ABILITY_GOD: AbilitySource = Pal.getAbilitySource("essentials", "invulnerable")
 
     fun register(dispatcher: CommandDispatcher<ServerCommandSource>) {
         Command.builder(dispatcher) {
-            command("god") {
+            command("invulnerable", "godmode") {
                 requires { it.hasPermissionLevel(4) }
-
-                executes(GodCommand::toggleGodSelf)
-                argument("player", EntityArgumentType.player()) {
+                executes(InvulnerableCommand::toggleGodSelf)
+                argument("target", EntityArgumentType.player()) {
                     requires { it.hasPermissionLevel(4) }
-                    executes(GodCommand::toggleGodOther)
+                    executes(InvulnerableCommand::toggleGodOther)
                 }
             }
         }
@@ -57,7 +57,7 @@ object GodCommand {
 
         // Send feedback
         context.source.sendFeedback(
-                LiteralText("Successfully toggled godmode"),
+                LiteralText("Successfully toggled invulnerable mode"),
                 false)
 
         return 1
@@ -65,14 +65,14 @@ object GodCommand {
 
     private fun toggleGodOther(context: CommandContext<ServerCommandSource>): Int {
         // Get player
-        val player = EntityArgumentType.getPlayer(context, "player")
+        val player = EntityArgumentType.getPlayer(context, "target")
 
         // Set god
         toggleGod(player)
 
         // Send feedback
         context.source.sendFeedback(
-                LiteralText("Successfully toggled godmode for ${player.displayName.asString()}"),
+                LiteralText("Successfully toggled invulnerable mode for ${player.displayName.asString()}"),
                 false)
 
         return 1

--- a/src/main/kotlin/io/github/gunpowder/commands/TrashCommand.kt
+++ b/src/main/kotlin/io/github/gunpowder/commands/TrashCommand.kt
@@ -31,7 +31,6 @@ import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.entity.player.PlayerInventory
 import net.minecraft.inventory.SimpleInventory
 import net.minecraft.screen.GenericContainerScreenHandler
-import net.minecraft.screen.ScreenHandlerFactory
 import net.minecraft.screen.SimpleNamedScreenHandlerFactory
 import net.minecraft.server.command.ServerCommandSource
 import net.minecraft.text.LiteralText
@@ -49,7 +48,9 @@ object TrashCommand {
         val player = context.source.player;
         val emptyInventory = SimpleInventory(27)
 
-        player.openHandledScreen(SimpleNamedScreenHandlerFactory(ScreenHandlerFactory { i: Int, playerInventory: PlayerInventory?, _: PlayerEntity? -> GenericContainerScreenHandler.createGeneric9x3(i, playerInventory, emptyInventory) }, LiteralText("Trash can")))
+        player.openHandledScreen(SimpleNamedScreenHandlerFactory({ i: Int, playerInventory: PlayerInventory?, _: PlayerEntity? ->
+            GenericContainerScreenHandler.createGeneric9x3(i, playerInventory, emptyInventory)
+        }, LiteralText("Trash can")))
 
         return 1
     }

--- a/src/main/kotlin/io/github/gunpowder/commands/WorkbenchCommand.kt
+++ b/src/main/kotlin/io/github/gunpowder/commands/WorkbenchCommand.kt
@@ -46,7 +46,7 @@ object WorkbenchCommand {
 
     private fun openWorkbench(context: CommandContext<ServerCommandSource>): Int {
         context.source.player.openHandledScreen(SimpleNamedScreenHandlerFactory({ i: Int,
-                                                                                  playerInventory: PlayerInventory?, _: PlayerEntity? ->
+                                                                                  playerInventory: PlayerInventory, _: PlayerEntity ->
             CraftingScreenHandler(i, playerInventory, ScreenHandlerContext.EMPTY)
         }, TranslatableText("container.crafting")))
         return 1

--- a/src/main/kotlin/io/github/gunpowder/commands/WorkbenchCommand.kt
+++ b/src/main/kotlin/io/github/gunpowder/commands/WorkbenchCommand.kt
@@ -31,7 +31,6 @@ import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.entity.player.PlayerInventory
 import net.minecraft.screen.CraftingScreenHandler
 import net.minecraft.screen.ScreenHandlerContext
-import net.minecraft.screen.ScreenHandlerFactory
 import net.minecraft.screen.SimpleNamedScreenHandlerFactory
 import net.minecraft.server.command.ServerCommandSource
 import net.minecraft.text.TranslatableText
@@ -39,14 +38,17 @@ import net.minecraft.text.TranslatableText
 object WorkbenchCommand {
     fun register(dispatcher: CommandDispatcher<ServerCommandSource>) {
         Command.builder(dispatcher) {
-            command("workbench", "wb") {
+            command("workbench", "wb", "craft") {
                 executes(WorkbenchCommand::openWorkbench)
             }
         }
     }
 
     private fun openWorkbench(context: CommandContext<ServerCommandSource>): Int {
-        context.source.player.openHandledScreen(SimpleNamedScreenHandlerFactory(ScreenHandlerFactory { i: Int, playerInventory: PlayerInventory?, _: PlayerEntity? -> CraftingScreenHandler(i, playerInventory, ScreenHandlerContext.EMPTY) }, TranslatableText("container.crafting")))
+        context.source.player.openHandledScreen(SimpleNamedScreenHandlerFactory({ i: Int,
+                                                                                  playerInventory: PlayerInventory?, _: PlayerEntity? ->
+            CraftingScreenHandler(i, playerInventory, ScreenHandlerContext.EMPTY)
+        }, TranslatableText("container.crafting")))
         return 1
     }
 }


### PR DESCRIPTION
Refactor:
 GodCommand -> InvulnerableCommand

Changes:
- EnderchestCommand:
You can now target a player to open their ender chest (operator level 4)

- HatCommand:
Wearables can no longer be used as hats!
You now get feedback for changing the hat.

- VanishCommand:
Added target argument.

- WorkbenchCommand:
Added `/craft` alias.

Renamed the argument "player" to "target" in all the commands

I plan to come back to these and update them once we have more command utilities.
