### PR TITLE
Vanish improvements

### DIFF
--- a/src/main/java/io/github/gunpowder/mixin/utilities/PlayerManagerMixin_Utilities.java
+++ b/src/main/java/io/github/gunpowder/mixin/utilities/PlayerManagerMixin_Utilities.java
@@ -1,0 +1,77 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 GunpowderMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.gunpowder.mixin.utilities;
+
+import com.mojang.authlib.GameProfile;
+import io.github.gunpowder.api.GunpowderMod;
+import io.github.gunpowder.mixin.cast.VanishedPlayerManager;
+import net.minecraft.server.PlayerManager;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.net.SocketAddress;
+import java.util.List;
+
+@Mixin(PlayerManager.class)
+public class PlayerManagerMixin_Utilities implements VanishedPlayerManager {
+
+    @Final
+    @Shadow
+    private List<ServerPlayerEntity> players;
+
+    @Final
+    @Shadow
+    protected int maxPlayers;
+
+    private int vanishedCount = 0;
+
+    @Inject(method = "checkCanJoin(Ljava/net/SocketAddress;Lcom/mojang/authlib/GameProfile;)Lnet/minecraft/text/Text;", at = @At("RETURN"), cancellable = true)
+    private void checkCanJoinServer(SocketAddress address, GameProfile profile, CallbackInfoReturnable<Text> cir) {
+        PlayerManager manager = GunpowderMod.getInstance().getServer().getPlayerManager();
+        cir.setReturnValue(
+                this.players.size() - ((VanishedPlayerManager) manager).getVanishedCount() >= this.maxPlayers && !manager.canBypassPlayerLimit(profile) ?
+                        new TranslatableText("multiplayer.disconnect.server_full") :
+                        null
+        );
+
+    }
+
+    @Override
+    public int getVanishedCount() {
+        return this.vanishedCount;
+    }
+
+    @Override
+    public void setVanishedCount(int vanishedCount) {
+        this.vanishedCount = vanishedCount;
+    }
+}

--- a/src/main/java/io/github/gunpowder/mixin/utilities/PlayerManagerMixin_Utilities.java
+++ b/src/main/java/io/github/gunpowder/mixin/utilities/PlayerManagerMixin_Utilities.java
@@ -54,7 +54,15 @@ public class PlayerManagerMixin_Utilities implements VanishedPlayerManager {
 
     private int vanishedCount = 0;
 
-    @Inject(method = "checkCanJoin(Ljava/net/SocketAddress;Lcom/mojang/authlib/GameProfile;)Lnet/minecraft/text/Text;", at = @At("RETURN"), cancellable = true)
+    @Inject(
+            method = "checkCanJoin(Ljava/net/SocketAddress;Lcom/mojang/authlib/GameProfile;)Lnet/minecraft/text/Text;",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/PlayerManager;canBypassPlayerLimit(Lcom/mojang/authlib/GameProfile;)Z",
+                    shift = At.Shift.BEFORE
+            ),
+            cancellable = true
+    )
     private void checkCanJoinServer(SocketAddress address, GameProfile profile, CallbackInfoReturnable<Text> cir) {
         PlayerManager manager = GunpowderMod.getInstance().getServer().getPlayerManager();
         cir.setReturnValue(
@@ -74,4 +82,6 @@ public class PlayerManagerMixin_Utilities implements VanishedPlayerManager {
     public void setVanishedCount(int vanishedCount) {
         this.vanishedCount = vanishedCount;
     }
+
+
 }

--- a/src/main/java/io/github/gunpowder/mixin/utilities/PlayerManagerMixin_Utilities.java
+++ b/src/main/java/io/github/gunpowder/mixin/utilities/PlayerManagerMixin_Utilities.java
@@ -58,13 +58,12 @@ public class PlayerManagerMixin_Utilities implements VanishedPlayerManager {
             method = "checkCanJoin(Ljava/net/SocketAddress;Lcom/mojang/authlib/GameProfile;)Lnet/minecraft/text/Text;",
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/server/PlayerManager;canBypassPlayerLimit(Lcom/mojang/authlib/GameProfile;)Z",
-                    shift = At.Shift.BEFORE
+                    target = "Lnet/minecraft/server/PlayerManager;canBypassPlayerLimit(Lcom/mojang/authlib/GameProfile;)Z"
             ),
             cancellable = true
     )
     private void checkCanJoinServer(SocketAddress address, GameProfile profile, CallbackInfoReturnable<Text> cir) {
-        PlayerManager manager = GunpowderMod.getInstance().getServer().getPlayerManager();
+        PlayerManager manager = (PlayerManager) (Object) this;
         cir.setReturnValue(
                 this.players.size() - ((VanishedPlayerManager) manager).getVanishedCount() >= this.maxPlayers && !manager.canBypassPlayerLimit(profile) ?
                         new TranslatableText("multiplayer.disconnect.server_full") :
@@ -82,6 +81,4 @@ public class PlayerManagerMixin_Utilities implements VanishedPlayerManager {
     public void setVanishedCount(int vanishedCount) {
         this.vanishedCount = vanishedCount;
     }
-
-
 }

--- a/src/main/java/io/github/gunpowder/mixin/utilities/QueryResponseS2CPacket_Utilities.java
+++ b/src/main/java/io/github/gunpowder/mixin/utilities/QueryResponseS2CPacket_Utilities.java
@@ -64,8 +64,12 @@ public class QueryResponseS2CPacket_Utilities {
             fakedGameProfiles.add(player.getGameProfile());
         }
 
-
-        ServerMetadata.Players fakedPlayers = new ServerMetadata.Players(GunpowderMod.getInstance().getServer().getMaxPlayerCount(), fakedGameProfiles.size());
+        int max = GunpowderMod.getInstance().getServer().getMaxPlayerCount();
+        if(max == playerList.size()) {
+            // Server is full, faking the max player count
+            max = fakedGameProfiles.size();
+        }
+        ServerMetadata.Players fakedPlayers = new ServerMetadata.Players(max, fakedGameProfiles.size());
 
         GameProfile[] gameProfiles = fakedGameProfiles.toArray(new GameProfile[0]);
         fakedPlayers.setSample(gameProfiles);

--- a/src/main/java/io/github/gunpowder/mixin/utilities/QueryResponseS2CPacket_Utilities.java
+++ b/src/main/java/io/github/gunpowder/mixin/utilities/QueryResponseS2CPacket_Utilities.java
@@ -1,0 +1,76 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 GunpowderMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.gunpowder.mixin.utilities;
+
+import com.mojang.authlib.GameProfile;
+import io.github.gunpowder.api.GunpowderMod;
+import io.github.gunpowder.mixin.cast.PlayerVanish;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.packet.s2c.query.QueryResponseS2CPacket;
+import net.minecraft.server.ServerMetadata;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Mixin(QueryResponseS2CPacket.class)
+public class QueryResponseS2CPacket_Utilities {
+
+    @Shadow
+    private ServerMetadata metadata;
+
+    @Inject(method = "write(Lnet/minecraft/network/PacketByteBuf;)V", at = @At("HEAD"))
+    private void excludeVanished(PacketByteBuf buf, CallbackInfo ci) {
+
+        // List where "faked" GameProfiles will be stored (all the players except vanished)
+        List<GameProfile> fakedGameProfiles = new ArrayList<>();
+        // Original player list
+        List<ServerPlayerEntity> playerList = GunpowderMod.getInstance().getServer().getPlayerManager().getPlayerList();
+
+        // Excluding vanished players
+        for (ServerPlayerEntity player : playerList) {
+            if (((PlayerVanish) player).isVanished()) {
+                continue;
+            }
+
+            fakedGameProfiles.add(player.getGameProfile());
+        }
+
+
+        ServerMetadata.Players fakedPlayers = new ServerMetadata.Players(GunpowderMod.getInstance().getServer().getMaxPlayerCount(), fakedGameProfiles.size());
+
+        GameProfile[] gameProfiles = fakedGameProfiles.toArray(new GameProfile[0]);
+        fakedPlayers.setSample(gameProfiles);
+
+        // Setting fake players to metadata
+        metadata.setPlayers(fakedPlayers);
+    }
+}

--- a/src/main/java/io/github/gunpowder/mixin/utilities/QueryResponseS2CPacket_Utilities.java
+++ b/src/main/java/io/github/gunpowder/mixin/utilities/QueryResponseS2CPacket_Utilities.java
@@ -29,6 +29,7 @@ import io.github.gunpowder.api.GunpowderMod;
 import io.github.gunpowder.mixin.cast.PlayerVanish;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.packet.s2c.query.QueryResponseS2CPacket;
+import net.minecraft.server.PlayerManager;
 import net.minecraft.server.ServerMetadata;
 import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
@@ -50,10 +51,12 @@ public class QueryResponseS2CPacket_Utilities {
     @Inject(method = "write(Lnet/minecraft/network/PacketByteBuf;)V", at = @At("HEAD"))
     private void excludeVanished(PacketByteBuf buf, CallbackInfo ci) {
 
+        final PlayerManager playerManager = GunpowderMod.getInstance().getServer().getPlayerManager();
+
         // List where "faked" GameProfiles will be stored (all the players except vanished)
         List<GameProfile> fakedGameProfiles = new ArrayList<>();
         // Original player list
-        List<ServerPlayerEntity> playerList = GunpowderMod.getInstance().getServer().getPlayerManager().getPlayerList();
+        List<ServerPlayerEntity> playerList = playerManager.getPlayerList();
 
         // Excluding vanished players
         for (ServerPlayerEntity player : playerList) {
@@ -65,10 +68,6 @@ public class QueryResponseS2CPacket_Utilities {
         }
 
         int max = GunpowderMod.getInstance().getServer().getMaxPlayerCount();
-        if(max == playerList.size()) {
-            // Server is full, faking the max player count
-            max = fakedGameProfiles.size();
-        }
         ServerMetadata.Players fakedPlayers = new ServerMetadata.Players(max, fakedGameProfiles.size());
 
         GameProfile[] gameProfiles = fakedGameProfiles.toArray(new GameProfile[0]);

--- a/src/main/java/io/github/gunpowder/mixin/utilities/ServerPlayNetworkHandlerMixin_Utilities.java
+++ b/src/main/java/io/github/gunpowder/mixin/utilities/ServerPlayNetworkHandlerMixin_Utilities.java
@@ -78,8 +78,8 @@ public class ServerPlayNetworkHandlerMixin_Utilities {
     )
     private void noVanishDisconnectMessage(Text reason, CallbackInfo ci) {
         if(((PlayerVanish) player).isVanished()) {
-            PlayerManager playerManager = this.server.getPlayerManager();
-            ((VanishedPlayerManager) playerManager).setVanishedCount(((VanishedPlayerManager) playerManager).getVanishedCount() - 1);
+            VanishedPlayerManager vanishedPlayerManager = (VanishedPlayerManager) this.server.getPlayerManager();
+            vanishedPlayerManager.setVanishedCount(vanishedPlayerManager.getVanishedCount() - 1);
             this.player.onDisconnect();
             this.server.getPlayerManager().remove(this.player);
             if (this.server.isHost(this.player.getGameProfile())) {

--- a/src/main/java/io/github/gunpowder/mixin/utilities/ServerPlayNetworkHandlerMixin_Utilities.java
+++ b/src/main/java/io/github/gunpowder/mixin/utilities/ServerPlayNetworkHandlerMixin_Utilities.java
@@ -24,23 +24,68 @@
 
 package io.github.gunpowder.mixin.utilities;
 
+import io.github.gunpowder.mixin.cast.PlayerVanish;
+import io.github.gunpowder.mixin.cast.VanishedPlayerManager;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.internal.logging.AbstractInternalLogger;
 import net.minecraft.network.Packet;
 import net.minecraft.network.packet.s2c.play.PlayerListS2CPacket;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.PlayerManager;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ServerPlayNetworkHandler.class)
 public class ServerPlayNetworkHandlerMixin_Utilities {
+
+    @Final
+    @Shadow
+    private static Logger LOGGER;
+
+    @Shadow
+    public ServerPlayerEntity player;
+
+    @Final
+    @Shadow
+    private MinecraftServer server;
+
+
     @Inject(method = "sendPacket(Lnet/minecraft/network/Packet;Lio/netty/util/concurrent/GenericFutureListener;)V", at = @At("HEAD"), cancellable = true)
     void noEmptyPlayerPacket(Packet<?> packet, GenericFutureListener<? extends Future<? super Void>> listener, CallbackInfo ci) {
         // Disabled as getEntries is client-only
         //if (packet instanceof PlayerListS2CPacket && ((PlayerListS2CPacket) packet).getEntries().size() == 0) {
         //    ci.cancel();
         //}
+    }
+
+    @Inject(
+            method = "onDisconnected(Lnet/minecraft/text/Text;)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/PlayerManager;broadcastChatMessage(Lnet/minecraft/text/Text;Lnet/minecraft/network/MessageType;Ljava/util/UUID;)V"
+            ),
+            cancellable = true
+    )
+    private void noVanishDisconnectMessage(Text reason, CallbackInfo ci) {
+        if(((PlayerVanish) player).isVanished()) {
+            PlayerManager playerManager = this.server.getPlayerManager();
+            ((VanishedPlayerManager) playerManager).setVanishedCount(((VanishedPlayerManager) playerManager).getVanishedCount() - 1);
+            this.player.onDisconnect();
+            this.server.getPlayerManager().remove(this.player);
+            if (this.server.isHost(this.player.getGameProfile())) {
+                LOGGER.info("Stopping singleplayer server as player logged out");
+                this.server.stop(false);
+            }
+            ci.cancel();
+        }
     }
 }

--- a/src/main/java/io/github/gunpowder/mixin/utilities/ServerPlayNetworkHandlerMixin_Utilities.java
+++ b/src/main/java/io/github/gunpowder/mixin/utilities/ServerPlayNetworkHandlerMixin_Utilities.java
@@ -71,7 +71,8 @@ public class ServerPlayNetworkHandlerMixin_Utilities {
             method = "onDisconnected(Lnet/minecraft/text/Text;)V",
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/server/PlayerManager;broadcastChatMessage(Lnet/minecraft/text/Text;Lnet/minecraft/network/MessageType;Ljava/util/UUID;)V"
+                    target = "Lnet/minecraft/server/PlayerManager;broadcastChatMessage(Lnet/minecraft/text/Text;Lnet/minecraft/network/MessageType;Ljava/util/UUID;)V",
+                    shift = At.Shift.BEFORE
             ),
             cancellable = true
     )

--- a/src/main/java/io/github/gunpowder/mixin/utilities/ServerPlayerEntityMixin_Utilities.java
+++ b/src/main/java/io/github/gunpowder/mixin/utilities/ServerPlayerEntityMixin_Utilities.java
@@ -27,7 +27,6 @@ package io.github.gunpowder.mixin.utilities;
 import io.github.gunpowder.api.GunpowderMod;
 import io.github.gunpowder.mixin.cast.PlayerVanish;
 import io.github.gunpowder.mixin.cast.VanishedPlayerManager;
-import net.fabricmc.fabric.impl.networking.server.EntityTrackerStreamAccessor;
 import net.minecraft.network.MessageType;
 import net.minecraft.network.packet.s2c.play.PlayerListS2CPacket;
 import net.minecraft.server.PlayerManager;

--- a/src/main/java/io/github/gunpowder/mixin/utilities/ServerPlayerEntityMixin_Utilities.java
+++ b/src/main/java/io/github/gunpowder/mixin/utilities/ServerPlayerEntityMixin_Utilities.java
@@ -26,6 +26,7 @@ package io.github.gunpowder.mixin.utilities;
 
 import io.github.gunpowder.api.GunpowderMod;
 import io.github.gunpowder.mixin.cast.PlayerVanish;
+import io.github.gunpowder.mixin.cast.VanishedPlayerManager;
 import net.fabricmc.fabric.impl.networking.server.EntityTrackerStreamAccessor;
 import net.minecraft.network.MessageType;
 import net.minecraft.network.packet.s2c.play.PlayerListS2CPacket;
@@ -63,6 +64,11 @@ public class ServerPlayerEntityMixin_Utilities implements PlayerVanish {
                         player
                 )
         );
+
+        // Updating vanished count
+        VanishedPlayerManager vanishedPlayerManager = (VanishedPlayerManager) playerManager;
+        int vanishedCount = vanishedPlayerManager.getVanishedCount();
+        vanishedPlayerManager.setVanishedCount(enabled ? vanishedCount + 1 : vanishedCount - 1);
 
         ThreadedAnvilChunkStorage storage = ((ServerChunkManager) player.world.getChunkManager()).threadedAnvilChunkStorage;
         EntityTrackerAccessor_Utilities trackerEntry = ((ThreadedAnvilChunkStorageAccessor_Utilities) storage).getEntityTrackers().get(player.getEntityId());

--- a/src/main/kotlin/io/github/gunpowder/mixin/cast/VanishedPlayerManager.kt
+++ b/src/main/kotlin/io/github/gunpowder/mixin/cast/VanishedPlayerManager.kt
@@ -1,0 +1,29 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 GunpowderMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.gunpowder.mixin.cast
+
+interface VanishedPlayerManager {
+    var vanishedCount: Int
+}

--- a/src/main/resources/mixins.utilities.gunpowder.json
+++ b/src/main/resources/mixins.utilities.gunpowder.json
@@ -8,6 +8,7 @@
     "ListCommandMixin_Utilities",
     "PlayerAbilitiesAccessor_Utilities",
     "PlayerListS2CPacketMixin_Utilities",
+    "QueryResponseS2CPacket_Utilities",
     "ServerPlayerEntityMixin_Utilities",
     "ServerPlayNetworkHandlerMixin_Utilities",
     "ThreadedAnvilChunkStorageAccessor_Utilities"

--- a/src/main/resources/mixins.utilities.gunpowder.json
+++ b/src/main/resources/mixins.utilities.gunpowder.json
@@ -8,6 +8,7 @@
     "ListCommandMixin_Utilities",
     "PlayerAbilitiesAccessor_Utilities",
     "PlayerListS2CPacketMixin_Utilities",
+    "PlayerManagerMixin_Utilities",
     "QueryResponseS2CPacket_Utilities",
     "ServerPlayerEntityMixin_Utilities",
     "ServerPlayNetworkHandlerMixin_Utilities",


### PR DESCRIPTION
This commit should fix issue #5 and #7 . It's a simple mixin injection to the write method of the query packet class.

As seen in the picture, there are actually 2 players online, but Alex is vanished.
![showcase](https://user-images.githubusercontent.com/34912839/93239637-5c53e580-f783-11ea-8ad3-9d1c3ffbeda9.png)


Should the server ping show 1/2 players online (player is still kicked upon joining since it's actually full) or should the max player count be modified as well? (So it would show 1/1 players online on the client)